### PR TITLE
Add test to make sure all project lists agree.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ cirrus-ci_task:
     cpu: 8
     memory: 12G
   configure_script:
-    - git submodule update --init --depth=5 --recursive
+    - git submodule update --init --depth=50 --recursive
   test_all_script:
     - bazel test -k
         --remote_http_cache=http://$CIRRUS_HTTP_CACHE_HOST

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -10,6 +10,7 @@ workspace(projects = [
     "echobot-jvm",
     "experimental",
     "go-toxcore-c",
+    "hs-cimple",
     "hs-github-tools",
     "hs-msgpack-binary",
     "hs-msgpack-rpc-conduit",

--- a/tools/git-remotes
+++ b/tools/git-remotes
@@ -30,12 +30,16 @@ sub irepo($) { $_[0] => $_[0] }
 sub nrepo($) { $_[0]->[0] => $_[0] }
 sub repo($) { ref $_[0] ? nrepo $_[0] : irepo $_[0] }
 
-my %repos = (
+our %REPOS = (
    'apidsl' => ['apidsl', {
       upstream => 'toktok',
       repo 'iphydf',
    }],
    'cedar' => ['cedar', {
+      upstream => 'toktok',
+      repo 'iphydf',
+   }],
+   'ci-tools' => ['ci-tools', {
       upstream => 'toktok',
       repo 'iphydf',
    }],
@@ -62,7 +66,15 @@ my %repos = (
       upstream => 'toktok',
       repo 'iphydf',
    }],
+   'experimental' => ['experimental', {
+      upstream => 'toktok',
+      repo 'iphydf',
+   }],
    'go-toxcore-c' => ['go-toxcore-c', {
+      upstream => 'toktok',
+      repo 'iphydf',
+   }],
+   'hs-cimple' => ['hs-cimple', {
       upstream => 'toktok',
       repo 'iphydf',
    }],
@@ -90,16 +102,16 @@ my %repos = (
       upstream => 'toktok',
       repo 'iphydf',
    }],
-   'hs-tools' => ['hs-tools', {
-      upstream => 'toktok',
-      repo 'iphydf',
-   }],
    'hs-toxcore' => ['hs-toxcore', {
       upstream => 'toktok',
       repo 'iphydf',
       repo 'zugz',
    }],
    'hs-toxcore-c' => ['hs-toxcore-c', {
+      upstream => 'toktok',
+      repo 'iphydf',
+   }],
+   'js-bugz' => ['js-bugz', {
       upstream => 'toktok',
       repo 'iphydf',
    }],
@@ -150,12 +162,20 @@ my %repos = (
       upstream => 'toktok',
       repo 'iphydf',
    }],
+   'tools/.github' => ['.github', {
+      upstream => 'toktok',
+      repo 'iphydf',
+   }],
    'toxic' => ['toxic', {
       upstream => 'toktok',
       repo 'iphydf',
    }],
    'toxins' => ['toxins', {
       upstream => 'toktok',
+      repo 'iphydf',
+   }],
+   'toxins/toxvpn/import' => ['toxvpn', {
+      upstream => 'cleverca22',
       repo 'iphydf',
    }],
    'website' => ['website', {
@@ -217,26 +237,28 @@ sub process_repos {
    }
 }
 
-my ($username) = @ARGV or die "Usage: git-remotes <username>\n";
+if (__PACKAGE__ eq 'main') {
+   my ($username) = @ARGV or die "Usage: git-remotes <username>\n";
 
-# Set 'origin' to our own username.
-for (values %repos) {
-   $_->[1]{origin} = $username;
-   delete $_->[1]{$username};
+   # Set 'origin' to our own username.
+   for (values %REPOS) {
+      $_->[1]{origin} = $username;
+      delete $_->[1]{$username};
+   }
+
+   # Set origin and upstream on toktok-stack.
+   add_remotes ['toktok-stack', {
+      upstream => 'toktok',
+      origin => $username,
+   }];
+
+   process_repos \%REPOS;
+
+   sub git_foreach {
+      system 'git', 'submodule', 'foreach', @_;
+   }
+
+   # Fetch all remotes and set master to track origin/master.
+   git_foreach 'git', 'fetch', '--all';
+   git_foreach 'git', 'branch', '--set-upstream-to=origin/master', 'master';
 }
-
-# Set origin and upstream on toktok-stack.
-add_remotes ['toktok-stack', {
-   upstream => 'toktok',
-   origin => $username,
-}];
-
-process_repos \%repos;
-
-sub git_foreach {
-   system 'git', 'submodule', 'foreach', @_;
-}
-
-# Fetch all remotes and set master to track origin/master.
-git_foreach 'git', 'fetch', '--all';
-git_foreach 'git', 'branch', '--set-upstream-to=origin/master', 'master';

--- a/tools/git_modules_test.pl
+++ b/tools/git_modules_test.pl
@@ -1,0 +1,80 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings FATAL => 'all';
+
+my ($GITMODULES, $GITREMOTES, @PROJECTS) = @ARGV;
+
+sub parse_gitmodules {
+   my ($file) = @_;
+
+   my %mods;
+   my $cur;
+
+   open my $fh, '<', $file or die "$file: $!";
+   while (<$fh>) {
+      if (m|^\[submodule "(.*)"\]$|) {
+         $cur = $mods{$1} = {};
+      } elsif (m|^\tpath = (.*)|) {
+         $cur->{path} = $1;
+      } elsif (m|^\turl = https://github.com/TokTok/(.*)|) {
+         $cur->{repo} = $1;
+      }
+   }
+
+   my %repos = map { $mods{$_}{path} => $mods{$_}{repo} } keys %mods;
+   \%repos;
+}
+
+sub parse_gitremotes {
+   package GitRemotes;
+   use File::Basename;
+
+   do "./$GITREMOTES";
+
+   my %repos;
+
+   sub is_subsubmodule {
+      my ($dir) = @_;
+      while ($dir ne '.' and $dir ne '/') {
+         $dir = dirname $dir;
+         return 1 if $GitRemotes::REPOS{$dir};
+      }
+      0
+   }
+
+   for my $path (keys %GitRemotes::REPOS) {
+      # Filter out submodules of submodules. They do appear in git-remotes, but
+      # not in .gitmodules, because they appear in the submodule's .gitmodules,
+      # which we're not testing.
+      next if is_subsubmodule $path;
+      $repos{$path} = $GitRemotes::REPOS{$path}[0];
+   }
+
+   \%repos
+}
+
+my $modules = parse_gitmodules $GITMODULES;
+my $remotes = parse_gitremotes $GITREMOTES;
+my %projects = map { $_ => undef } @PROJECTS;
+
+# Check that .gitmodules doesn't have more modules than git-remotes.
+for my $repo (sort keys %$modules) {
+   die ".gitmodules contains submodule '$repo' not listed in %REPOS in $GITREMOTES\n"
+      unless exists $remotes->{$repo};
+}
+# And vice-versa.
+for my $repo (sort keys %$remotes) {
+   die "$GITREMOTES contains repository '$repo' not listed in .gitmodules\n"
+      unless exists $modules->{$repo};
+}
+# Check that tools/BUILD.bazel knows about all our projects.
+for my $repo (sort keys %$modules) {
+   die ".gitmodules contains submodule '$repo' not listed in projects in tools/BUILD.bazel\n"
+      unless exists $projects{$repo};
+}
+# And it doesn't have too many.
+for my $repo (sort @PROJECTS) {
+   die "tools/BUILD.bazel lists project '$repo' that isn't listed in .gitmodules"
+      unless exists $modules->{$repo};
+}

--- a/tools/gitmodules
+++ b/tools/gitmodules
@@ -1,0 +1,1 @@
+../.gitmodules

--- a/tools/project/build_defs.bzl
+++ b/tools/project/build_defs.bzl
@@ -108,6 +108,20 @@ def project(license = "gpl3", standard_travis = False):
         )
 
 def workspace(projects):
+    native.sh_test(
+        name = "git_modules_test",
+        size = "small",
+        srcs = [":git_modules_test.pl"],
+        args = [
+            "$(location gitmodules)",
+            "$(location git-remotes)",
+        ] + projects,
+        data = [
+            "gitmodules",
+            "git-remotes",
+        ],
+    )
+
     native.test_suite(
         name = "license_tests",
         tests = ["//%s:license_test" % p for p in projects],


### PR DESCRIPTION
Project lists are:
* .gitmodules
* tools/git-remotes
* tools/BUILD.bazel

Added a symlink to .gitmodules in tools/gitmodules. This is needed
because we don't have access to `//:.gitmodules`. We could easily have
access to it, but that means adding it to the toplevel BUILD.bazel, which
in turn means .gitmodules becomes part of the minimal bootstrap set we
need for building the Docker image. We'd like to avoid having to rebuild
the Docker image from scratch (6GB upload) whenever we add/remove/rename
a submodule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/71)
<!-- Reviewable:end -->
