### PR TITLE
Stop using stropts.h. It disappeared in ubuntu focal.

### DIFF
--- a/third_party/curl/linux/curl_config.h
+++ b/third_party/curl/linux/curl_config.h
@@ -650,7 +650,7 @@
 /* #undef HAVE_STRNICMP */
 
 /* Define to 1 if you have the <stropts.h> header file. */
-#define HAVE_STROPTS_H 1
+/* #undef HAVE_STROPTS_H */
 
 /* Define to 1 if you have the strstr function. */
 #define HAVE_STRSTR 1


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/77)
<!-- Reviewable:end -->
