### PR TITLE
Enable bazel strict mode by default.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -106,100 +106,6 @@ build --experimental_run_validations
 build --experimental_strict_fileset_output
 build --experimental_strict_java_deps=warn
 
-# https://docs.bazel.build/versions/master/skylark/backward-compatibility.html
-#build:strict --all_incompatible_changes
-
-build:strict --incompatible_allow_python_version_transitions
-build:strict --incompatible_always_check_depset_elements
-build:strict --incompatible_applicable_licenses
-build:strict --incompatible_auto_configure_host_platform
-build:strict --incompatible_default_to_explicit_init_py
-build:strict --incompatible_depset_for_libraries_to_link_getter
-build:strict --incompatible_disable_cc_configuration_make_variables
-build:strict --incompatible_disable_cc_toolchain_label_from_crosstool_proto
-build:strict --incompatible_disable_crosstool_file
-build:strict --incompatible_disable_deprecated_attr_params
-build:strict --incompatible_disable_depset_in_cc_user_flags
-build:strict --incompatible_disable_depset_items
-build:strict --incompatible_disable_expand_if_all_available_in_flag_set
-build:strict --incompatible_disable_late_bound_option_defaults
-build:strict --incompatible_disable_legacy_cc_provider
-build:strict --incompatible_disable_legacy_cpp_toolchain_skylark_api
-build:strict --incompatible_disable_legacy_crosstool_fields
-build:strict --incompatible_disable_legacy_flags_cc_toolchain_api
-build:strict --incompatible_disable_legacy_proto_provider
-build:strict --incompatible_disable_native_android_rules="false"
-build:strict --incompatible_disable_nocopts
-build:strict --incompatible_disable_proto_source_root
-build:strict --incompatible_disable_runtimes_filegroups
-build:strict --incompatible_disable_static_cc_toolchains
-build:strict --incompatible_disable_sysroot_from_configuration
-build:strict --incompatible_disable_target_provider_fields
-build:strict --incompatible_disable_third_party_license_checking
-build:strict --incompatible_disable_tools_defaults_package
-build:strict --incompatible_disallow_empty_glob
-build:strict --incompatible_disallow_legacy_javainfo
-build:strict --incompatible_disallow_legacy_java_provider
-build:strict --incompatible_disallow_legacy_py_provider
-build:strict --incompatible_disallow_resource_jars
-build:strict --incompatible_disallow_struct_provider_syntax="false"
-build:strict --incompatible_do_not_emit_buggy_external_repo_import
-build:strict --incompatible_do_not_split_linking_cmdline
-build:strict --incompatible_dont_emit_static_libgcc
-build:strict --incompatible_dont_enable_host_nonhost_crosstool_features
-build:strict --incompatible_enable_cc_toolchain_resolution="false"  # TODO(iphydf): This breaks remote-exec.
-build:strict --incompatible_enable_legacy_cpp_toolchain_skylark_api
-build:strict --incompatible_enable_profile_by_default
-build:strict --incompatible_generated_protos_in_virtual_imports
-build:strict --incompatible_linkopts_in_user_link_flags
-build:strict --incompatible_linkopts_to_linklibs
-build:strict --incompatible_load_cc_rules_from_bzl="false"
-build:strict --incompatible_load_java_rules_from_bzl="false"
-build:strict --incompatible_load_proto_rules_from_bzl
-build:strict --incompatible_load_python_rules_from_bzl
-build:strict --incompatible_make_thinlto_command_lines_standalone
-build:strict --incompatible_merge_genfiles_directory
-build:strict --incompatible_new_actions_api
-build:strict --incompatible_no_attr_license
-build:strict --incompatible_no_implicit_file_export="false"
-build:strict --incompatible_no_rule_outputs_param="false"
-build:strict --incompatible_no_support_tools_in_action_inputs
-build:strict --incompatible_no_target_output_group
-build:strict --incompatible_objc_compile_info_migration
-build:strict --incompatible_prohibit_aapt1
-build:strict --incompatible_provide_cc_toolchain_info_from_cc_toolchain_suite
-build:strict --incompatible_py2_outputs_are_suffixed
-build:strict --incompatible_py3_is_default
-build:strict --incompatible_remote_results_ignore_disk
-build:strict --incompatible_remote_symlinks
-build:strict --incompatible_remove_binary_profile
-build:strict --incompatible_remove_cpu_and_compiler_attributes_from_cc_toolchain
-build:strict --incompatible_remove_legacy_whole_archive
-build:strict --incompatible_remove_local_resources
-build:strict --incompatible_remove_old_python_version_api
-build:strict --incompatible_remove_ram_utilization_factor
-build:strict --incompatible_require_ctx_in_configure_features
-build:strict --incompatible_require_feature_configuration_for_pic
-build:strict --incompatible_require_java_toolchain_header_compiler_direct
-build:strict --incompatible_require_linker_input_cc_api="false"  # io_bazel_rules_go
-build:strict --incompatible_restrict_string_escapes
-build:strict --incompatible_run_shell_command_string
-build:strict --incompatible_skip_genfiles_symlink
-build:strict --incompatible_strict_action_env
-build:strict --incompatible_symlinked_sandbox_expands_tree_artifacts_in_runfiles_tree
-build:strict --incompatible_use_cc_configure_from_rules_cc
-build:strict --incompatible_use_native_patch
-build:strict --incompatible_use_platforms_repo_for_constraints="false"
-build:strict --incompatible_use_python_toolchains
-build:strict --incompatible_use_specific_tool_files
-build:strict --incompatible_use_toolchain_resolution_for_java_rules="false"  # TODO(https://github.com/bazelbuild/bazel/issues/7849): Enable.
-build:strict --incompatible_validate_top_level_header_inclusions
-build:strict --incompatible_visibility_private_attributes_at_definition
-
-# rules_apple uses old style list commands.
-# TODO(https://github.com/bazelbuild/rules_apple/issues/736): Remove.
-build:macos --incompatible_run_shell_command_string="false"
-
 ##############################################################################
 #
 # :: C/C++ compiler flags.
@@ -498,10 +404,13 @@ build:ci --show_timestamps
 build:ci --verbose_failures
 
 # Docker image build toxchat/toktok-stack running clang-11.
+build:docker --config=clang
+
+# Clang 11 has some extra warnings we need to selectively disable.
 build:docker --per_file_copt='c-toxcore@-Wno-c99-extensions'
+build:docker --per_file_copt='external/ffmpeg@-Wno-bool-operation'
 build:docker --per_file_copt='external/ffmpeg@-Wno-implicit-int-float-conversion'
 build:docker --per_file_copt='external/ffmpeg@-Wno-misleading-indentation'
-build:docker --per_file_copt='external/ffmpeg@-Wno-bool-operation'
 build:docker --per_file_copt='external/portaudio@-Wno-implicit-int-float-conversion'
 build:docker --per_file_copt='external/yasm@-Wno-misleading-indentation'
 build:docker --per_file_copt='(moc_.*.cpp|_test.cpp)@-Wno-extra-semi-stmt'

--- a/.bazelrc.local.example
+++ b/.bazelrc.local.example
@@ -28,11 +28,6 @@ build --config=clang
 #build --config=debug
 #build --config=release
 
-# Enable this to get Bazel deprecation warnings for future feature changes.
-# Disable this if you're running with an older version of Bazel that doesn't
-# support some of the --incompatible flags.
-build --config=strict
-
 # Use this config to put tox into a test network that speaks an incompatible
 # protocol (all packet ids are shifted).
 #build --config=testnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ cache:
 
 before_cache:
   - OUTPUT_BASE=$(bazel info output_base)
-  - rm -rf $HOME/.cache/bazel/_bazel_$USER/cache
-  - rm -rf $HOME/.cache/bazel/_bazel_$USER/install
-  - rm -f $OUTPUT_BASE/action_cache/action_journal_*.blaze
-  - rm -f $OUTPUT_BASE/bazel-workers/worker-*.log
-  - rm -f $OUTPUT_BASE/command.log
-  - rm -f $OUTPUT_BASE/command.profile.gz
-  - rm -f $OUTPUT_BASE/execroot/toktok/bazel-out/stable-status.txt
+  - rm -rf
+    $HOME/.cache/bazel/_bazel_$USER/cache
+    $HOME/.cache/bazel/_bazel_$USER/install
+    $OUTPUT_BASE/action_cache/action_journal_*.blaze
+    $OUTPUT_BASE/bazel-workers/worker-*.log
+    $OUTPUT_BASE/command.log
+    $OUTPUT_BASE/command.profile.gz
+    $OUTPUT_BASE/execroot/toktok/bazel-out/stable-status.txt
+    $OUTPUT_BASE/execroot/toktok/bazel-out/volatile-status.txt
+    $OUTPUT_BASE/java.log*
+    $OUTPUT_BASE/lock
+    $OUTPUT_BASE/server
 
 jobs:
   include:
@@ -40,10 +45,12 @@ jobs:
         apt:
           packages:
             - libasound-dev
+            - libqt5opengl5-dev
             - libqt5svg5-dev
             - libssl-dev
             - libx264-dev
             - python3.5-dev
+            - qtmultimedia5-dev
             - qttools5-dev
             - qttools5-dev-tools
       before_install: source tools/setup-bazel

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -29,6 +29,7 @@ elif sys.version_info.major == 2:
         if process.returncode == 0:
             return json.loads(stdout)
         if process.returncode == 2:
+            print(stderr)
             raise Exception(json.loads(stdout)["message"])
         else:
             raise Exception(stderr)

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN bazel aquery --output=proto --show_timestamps //... > /dev/null
 # Now we can copy the entire tree. This is expected to change very often, as it
 # includes all of the sources of all projects.
 COPY workspace /src/workspace/
+COPY workspace/tools/bazelrc.docker /src/workspace/.bazelrc.local
 
 # Finally, we run another aquery. This will download some more dependencies, but
 # the most expensive ones should already have been downloaded above.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE		= toxchat/toktok-stack:0.0.8
+IMAGE		= toxchat/toktok-stack:0.0.9
 DOWNLOADS	= toxchat/toktok-stack:downloads
 
 CACHE		= /tmp/build_cache
@@ -15,7 +15,7 @@ build: build-workspace
 
 # Run the Bazel build in the built image without persisting any state.
 run:
-	docker run --rm -it $(IMAGE) bazel $(ACTION) //... $(BAZELFLAGS)
+	docker run --rm -it $(IMAGE) bazel $(ACTION) //...
 
 run-local: $(CACHE) $(OUTPUT)
 	docker run -v $(CURDIR):/src/workspace $(DOCKERFLAGS)
@@ -23,17 +23,14 @@ run-local: $(CACHE) $(OUTPUT)
 run-persistent: $(CACHE) $(OUTPUT)
 	docker run $(DOCKERFLAGS)
 
-BAZELFLAGS = --config=release --config=docker
-
 # Common flags for the rules above.
 DOCKERFLAGS := --rm -it					\
-	-e USER="$(shell id -u)" -u="$(shell id -u)"	\
 	-v $(CACHE):/tmp/build_cache			\
 	-v $(OUTPUT):/tmp/build_output			\
 	$(IMAGE) bazel					\
 	--output_user_root=/tmp/build_cache		\
 	--output_base=/tmp/build_output			\
-	$(ACTION) //... $(BAZELFLAGS)
+	$(ACTION) //...
 
 #######################################
 # Implementation details follow

--- a/tools/bazelrc.boot
+++ b/tools/bazelrc.boot
@@ -9,3 +9,105 @@ build --experimental_disable_external_package
 build --experimental_ninja_actions
 build --experimental_repository_cache_hardlinks
 build --record_rule_instantiation_callstack
+
+# We enable these to get Bazel deprecation warnings for future feature changes.
+# Disable them if you're running with an older version of Bazel that doesn't
+# support some of the --incompatible flags.
+#
+# They need to be in bazelrc.boot because some of them affect how the workspace
+# is laid out. We could figure out which ones do and which don't, but then we'd
+# need to split them between two files. It's better to keep them all here.
+#
+# https://docs.bazel.build/versions/master/skylark/backward-compatibility.html
+#build --all_incompatible_changes
+
+build --incompatible_allow_python_version_transitions
+build --incompatible_always_check_depset_elements
+build --incompatible_applicable_licenses
+build --incompatible_auto_configure_host_platform
+build --incompatible_default_to_explicit_init_py
+build --incompatible_depset_for_libraries_to_link_getter
+build --incompatible_disable_cc_configuration_make_variables
+build --incompatible_disable_cc_toolchain_label_from_crosstool_proto
+build --incompatible_disable_crosstool_file
+build --incompatible_disable_deprecated_attr_params
+build --incompatible_disable_depset_in_cc_user_flags
+build --incompatible_disable_depset_items
+build --incompatible_disable_expand_if_all_available_in_flag_set
+build --incompatible_disable_late_bound_option_defaults
+build --incompatible_disable_legacy_cc_provider
+build --incompatible_disable_legacy_cpp_toolchain_skylark_api
+build --incompatible_disable_legacy_crosstool_fields
+build --incompatible_disable_legacy_flags_cc_toolchain_api
+build --incompatible_disable_legacy_proto_provider
+build --incompatible_disable_native_android_rules="false"
+build --incompatible_disable_nocopts
+build --incompatible_disable_proto_source_root
+build --incompatible_disable_runtimes_filegroups
+build --incompatible_disable_static_cc_toolchains
+build --incompatible_disable_sysroot_from_configuration
+build --incompatible_disable_target_provider_fields
+build --incompatible_disable_third_party_license_checking
+build --incompatible_disable_tools_defaults_package
+build --incompatible_disallow_empty_glob
+build --incompatible_disallow_legacy_javainfo
+build --incompatible_disallow_legacy_java_provider
+build --incompatible_disallow_legacy_py_provider
+build --incompatible_disallow_resource_jars
+build --incompatible_disallow_struct_provider_syntax="false"
+build --incompatible_do_not_emit_buggy_external_repo_import
+build --incompatible_do_not_split_linking_cmdline
+build --incompatible_dont_emit_static_libgcc
+build --incompatible_dont_enable_host_nonhost_crosstool_features
+build --incompatible_enable_cc_toolchain_resolution="false"  # TODO(iphydf): This breaks remote-exec.
+build --incompatible_enable_legacy_cpp_toolchain_skylark_api
+build --incompatible_enable_profile_by_default
+build --incompatible_generated_protos_in_virtual_imports
+build --incompatible_linkopts_in_user_link_flags
+build --incompatible_linkopts_to_linklibs
+build --incompatible_load_cc_rules_from_bzl="false"
+build --incompatible_load_java_rules_from_bzl="false"
+build --incompatible_load_proto_rules_from_bzl
+build --incompatible_load_python_rules_from_bzl
+build --incompatible_make_thinlto_command_lines_standalone
+build --incompatible_merge_genfiles_directory
+build --incompatible_new_actions_api
+build --incompatible_no_attr_license
+build --incompatible_no_implicit_file_export="false"
+build --incompatible_no_rule_outputs_param="false"
+build --incompatible_no_support_tools_in_action_inputs
+build --incompatible_no_target_output_group
+build --incompatible_objc_compile_info_migration
+build --incompatible_prohibit_aapt1
+build --incompatible_provide_cc_toolchain_info_from_cc_toolchain_suite
+build --incompatible_py2_outputs_are_suffixed
+build --incompatible_py3_is_default
+build --incompatible_remote_results_ignore_disk
+build --incompatible_remote_symlinks
+build --incompatible_remove_binary_profile
+build --incompatible_remove_cpu_and_compiler_attributes_from_cc_toolchain
+build --incompatible_remove_legacy_whole_archive
+build --incompatible_remove_local_resources
+build --incompatible_remove_old_python_version_api
+build --incompatible_remove_ram_utilization_factor
+build --incompatible_require_ctx_in_configure_features
+build --incompatible_require_feature_configuration_for_pic
+build --incompatible_require_java_toolchain_header_compiler_direct
+build --incompatible_require_linker_input_cc_api="false"  # io_bazel_rules_go
+build --incompatible_restrict_string_escapes="false"  # kythe
+build --incompatible_run_shell_command_string
+build --incompatible_skip_genfiles_symlink
+build --incompatible_strict_action_env
+build --incompatible_symlinked_sandbox_expands_tree_artifacts_in_runfiles_tree
+build --incompatible_use_cc_configure_from_rules_cc
+build --incompatible_use_native_patch
+build --incompatible_use_platforms_repo_for_constraints="false"
+build --incompatible_use_python_toolchains
+build --incompatible_use_specific_tool_files
+build --incompatible_use_toolchain_resolution_for_java_rules="false"  # TODO(https://github.com/bazelbuild/bazel/issues/7849): Enable.
+build --incompatible_validate_top_level_header_inclusions
+build --incompatible_visibility_private_attributes_at_definition
+
+# rules_apple uses old style list commands.
+# TODO(https://github.com/bazelbuild/rules_apple/issues/736): Remove.
+build:macos --incompatible_run_shell_command_string="false"

--- a/tools/bazelrc.docker
+++ b/tools/bazelrc.docker
@@ -1,0 +1,9 @@
+# Bazel config for the toktok-stack Docker image.
+
+# Set the default fairly high so the Docker image utilises many cores if it can.
+build --jobs=16
+
+# The "docker" config includes all flags needed to successfully build all of
+# toktok-stock. Users may pass additional flags like --config=release. By
+# default, the Docker image builds in fastbuild mode.
+build --config=docker

--- a/tools/kythe/ycm_extra_conf.py
+++ b/tools/kythe/ycm_extra_conf.py
@@ -10,12 +10,13 @@ import builder
 
 logging.basicConfig(level=logging.DEBUG)
 
+
 # pylint: disable=invalid-name
 def Settings(
         language: str,
         filename: Optional[str] = None,
         client_data: Any = None,
-    ) -> Dict[str, List[str]]:
+) -> Dict[str, List[str]]:
     """Return flags for the file loaded into vim."""
     del client_data
 
@@ -28,8 +29,10 @@ def Settings(
     db = bazel.generate_compilation_database([filename])
     if not db:
         raise Exception(filename)
-    flags = builder.filter_for_clang(shlex.split(db[0]["command"])[1:])
+    flags = builder.flags_for_clang(bazel.execution_root(),
+                                    shlex.split(db[0]["command"])[1:])
     return {"flags": flags}
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
It must be enabled in the docker image, so for simplicity, we enable it
always. To disable, you'll now need to edit tools/bazelrc.boot. It's no
longer a control in .bazerc.local.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/87)
<!-- Reviewable:end -->
