### PR TITLE
Allow sub-repos to bring their own .bazelrc.local.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ build --process_headers_in_dependencies
 #build --remote_download_minimal
 build --strict_filesets=true
 build --enable_platform_specific_config
+build --watchfs
 
 # TODO(https://github.com/tweag/rules_haskell/issues/1312): Remove this once
 # rules_haskell is happy without it.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-IMAGE		= toxchat/toktok-stack:0.0.9
-DOWNLOADS	= toxchat/toktok-stack:downloads
+IMAGE		= toxchat/toktok-stack:0.0.10
 
 CACHE		= /tmp/build_cache
 OUTPUT		= /dev/shm/build_output
@@ -64,7 +63,7 @@ DOCKER_BUILD = docker build --ulimit memlock=67108864
 
 # We use an intermediate target here so "make" does the cleanup of workspace.tar
 # for us. It has to be 2 levels deep, otherwise it's considered "precious".
-build-%: %.tar downloads-%
+build-%: %.tar
 	$(DOCKER_BUILD) -t $(IMAGE) - < $<
 
 build-kythe: kythe.tar tools/kythe/Dockerfile
@@ -72,12 +71,6 @@ build-kythe: kythe.tar tools/kythe/Dockerfile
 	$(DOCKER_BUILD) -t toxchat/kythe-serving dockerfiles/kythe/serving
 
 TAR = tar --mode=ugo+rx --transform 's,^,$*/,;s,^$*/Dockerfile,Dockerfile,'
-
-# This is the intermediate image, which is huge and doesn't try to be efficient.
-# We copy the populated third_party directory from it into the final image.
-downloads-%: Dockerfile tools/prepare_third_party.sh
-	$(TAR) -c Dockerfile tools/prepare_third_party.sh \
-		| docker build --target downloads -t $(DOWNLOADS) -
 
 # Build a .tar with the workspace in it. This will be unpacked in the
 # Dockerfile. We use $(...) in bash instead of $(shell) in make because

--- a/tools/inject-repo
+++ b/tools/inject-repo
@@ -18,9 +18,7 @@ rm "$REPO"
 mv /tmp/cirrus-ci-repo "$REPO"
 cd /tmp/cirrus-ci-build
 
-# Set up .bazelrc.local from the example in toktok-stack.
-cp ".bazelrc.local.example" ".bazelrc.local"
 if [ -f "$REPO/.bazelrc.local" ]; then
   # If the repo has customisations, add those here.
-  cat "$REPO/.bazelrc.local" >> ".bazelrc.local"
+  cp "$REPO/.bazelrc.local" ".bazelrc.local"
 fi


### PR DESCRIPTION
Set up the Docker image in a way such that a parameterless build works.
Local customisation in .bazelrc.local should be for things like changing
the compilation mode, adding asan, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/89)
<!-- Reviewable:end -->
