### PR TITLE
chore: Add missing linker option to link openal to libdl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build artifacts.
+/.clangd
 /.vs
 /.stack-work
 /stack.yaml.lock

--- a/third_party/BUILD.openal
+++ b/third_party/BUILD.openal
@@ -106,6 +106,7 @@ cc_library(
         "@toktok//tools/config:windows": [],
     }),
     copts = COPTS,
+    linkopts = ["-ldl"],
     deps = [
         ":public",
         #"@sdl2",


### PR DESCRIPTION
This won't work on windows, but we'll fix that later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/129)
<!-- Reviewable:end -->
