### PR TITLE
chore: Move Qt deps installation out of the toktok-stack image.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -65,7 +65,7 @@ build:remote --remote_http_cache=https://code.tox.chat/bazel
 # Use remote execution. Disabled by default, because we don't want everyone to
 # use the remote executors (and they might be down sometimes).
 build:remote-exec --remote_executor=grpc://code.tox.chat:8980
-build:remote-exec --config=docker
+build:remote-exec --config=rbe
 
 # Use local docker sandbox. This is a lot slower than linux-sandbox, but is more
 # hermetic and reproducible, so it is used on our CI.
@@ -73,7 +73,7 @@ build:docker-sandbox --experimental_docker_image=toxchat/builder:latest
 build:docker-sandbox --experimental_docker_verbose
 build:docker-sandbox --experimental_enable_docker_sandbox
 build:docker-sandbox --define=EXECUTOR=remote
-build:docker-sandbox --config=docker
+build:docker-sandbox --config=rbe
 
 build:docker-sandbox --genrule_strategy=docker
 build:docker-sandbox --spawn_strategy=docker
@@ -439,8 +439,8 @@ build:ci --jobs=50
 build:ci --show_timestamps
 build:ci --verbose_failures
 
-# Docker image build toxchat/toktok-stack running clang-14.
-build:docker --config=clang
+# The "rbe" config sets up the toolchains for clang-14.
+build:rbe --config=clang
 
 # Docker build doesn't support IPv6.
 build:docker --config=ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,5 @@
 FROM toxchat/bazel:latest
 
-# Install toktok-stack dependencies.
-RUN apt-get update \
- && DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
- libasound2-dev \
- libgmp-dev \
- libncurses5-dev \
- libncursesw5-dev \
- libqt5opengl5-dev \
- libqt5svg5-dev \
- libssl-dev \
- libtinfo5 \
- libxcb-xfixes0-dev \
- libx264-dev \
- libxss-dev \
- libxxf86vm-dev \
- make \
- maven \
- qtmultimedia5-dev \
- qttools5-dev \
- qttools5-dev-tools \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
 # First, we copy all the unpacked third_party downloads into the image. These
 # are rarely changing, so we won't need to rebuild this part of the image often.
 # Dependencies installed with apt above should never change, as we should be

--- a/tools/bazelrc.boot
+++ b/tools/bazelrc.boot
@@ -40,18 +40,22 @@ build --incompatible_use_toolchain_resolution_for_java_rules="false"  # TODO(htt
 build:macos --incompatible_run_shell_command_string="false"
 
 # Java toolchain.
-build:docker --extra_toolchains=//tools/toolchain/java:all
-build:docker --host_javabase=//tools/toolchain/java:jdk
-build:docker --javabase=//tools/toolchain/java:jdk
+build:rbe --extra_toolchains=//tools/toolchain/java:all
+build:rbe --host_javabase=//tools/toolchain/java:jdk
+build:rbe --javabase=//tools/toolchain/java:jdk
 
 # C/C++ toolchain.
-build:docker --extra_toolchains=//tools/toolchain/config:cc-toolchain
-build:docker --crosstool_top=//tools/toolchain/cc:toolchain
+build:rbe --extra_toolchains=//tools/toolchain/config:cc-toolchain
+build:rbe --crosstool_top=//tools/toolchain/cc:toolchain
 
 # Platform flags:
 # The toolchain container used for execution is defined in the target indicated
 # by "extra_execution_platforms", "host_platform" and "platforms".
 # More about platforms: https://docs.bazel.build/versions/master/platforms.html
-build:docker --extra_execution_platforms=//tools/toolchain/config:platform
-build:docker --host_platform=//tools/toolchain/config:platform
-build:docker --platforms=//tools/toolchain/config:platform
+build:rbe --extra_execution_platforms=//tools/toolchain/config:platform
+build:rbe --host_platform=//tools/toolchain/config:platform
+build:rbe --platforms=//tools/toolchain/config:platform
+
+# Docker image build toxchat/toktok-stack running clang-14 in the
+# toxchat/builder image.
+build:docker --config=rbe

--- a/tools/prepare_toolchain.sh
+++ b/tools/prepare_toolchain.sh
@@ -5,9 +5,11 @@ set -eux
 wget -O /tmp/rbe_configs_gen https://github.com/bazelbuild/bazel-toolchains/releases/download/v5.1.1/rbe_configs_gen_linux_amd64
 chmod +x /tmp/rbe_configs_gen
 
+# This uses toxchat/bazel instead of toxchat/builder so it can see all the
+# installed headers for the various out-of-tree system dependencies.
 /tmp/rbe_configs_gen \
   --bazel_version="$(cat .bazelversion)" \
-  --toolchain_container=toxchat/builder:latest \
+  --toolchain_container=toxchat/bazel:latest \
   --output_src_root="$PWD" \
   --output_config_path=tools/toolchain \
   --exec_os=linux \


### PR DESCRIPTION
This is now done in the bazel base image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/278)
<!-- Reviewable:end -->
