### PR TITLE
chore: Split docker build in `latest-third_party` and `latest`.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,26 +12,6 @@ on:
     branches: [master]
 
 jobs:
-  kythe:
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.title, 'chore(deps)') }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - name: Build Kythe tables
-        run: make build-kythe
-      - name: Login to DockerHub
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push Kythe image to DockerHub
-        if: ${{ github.event_name == 'push' }}
-        run: make push-kythe
-
   docker-release:
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +21,9 @@ jobs:
           submodules: recursive
       - name: Pull latest toktok-stack image
         if: ${{ !(contains(github.event.pull_request.title, 'chore(rebuild)') || contains(github.event.head_commit.message, 'chore(rebuild)')) }}
-        run: docker pull toxchat/toktok-stack:latest
+        run: |
+          docker pull toxchat/toktok-stack:latest-third_party || true
+          docker pull toxchat/toktok-stack:latest
       - name: Build toktok-stack base image
         run: make build-workspace
       - name: Login to DockerHub
@@ -165,3 +147,23 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push tsan image to DockerHub
         run: make -C tools/built push-tsan
+
+  kythe:
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.title, 'chore(deps)') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Build Kythe tables
+        run: make build-kythe
+      - name: Login to DockerHub
+        if: ${{ github.event_name == 'push' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Push Kythe image to DockerHub
+        if: ${{ github.event_name == 'push' }}
+        run: make push-kythe

--- a/tools/built/Makefile
+++ b/tools/built/Makefile
@@ -1,17 +1,13 @@
-VERSION = $(shell make -s -C ../.. version)
-
 build: build-release build-fastbuild build-debug build-asan build-msan build-tsan
 push: push-release build-fastbuild push-debug push-asan push-msan push-tsan
 
 build-%: src/Dockerfile.%
-	docker build -t toxchat/toktok-stack:$(VERSION)-$* -t toxchat/toktok-stack:latest-$* src -f $<
+	docker build -t toxchat/toktok-stack:latest-$* src -f $<
 
 push-%: build-%
-	docker push toxchat/toktok-stack:$(VERSION)-$*
 	docker push toxchat/toktok-stack:latest-$*
 
 clean-%:
-	docker rmi toxchat/toktok-stack:$(VERSION)-$*
 	docker rmi toxchat/toktok-stack:latest-$*
 	-docker rm $(docker ps -a | grep -o '^[0-9a-f]...........')
 	-docker rmi $$(docker images -f "dangling=true" -q)

--- a/tools/built/dev/Dockerfile
+++ b/tools/built/dev/Dockerfile
@@ -3,18 +3,14 @@
 # See run_dev_container.sh for an example usage.
 FROM toxchat/toktok-stack:latest-dev
 
-# Copy the local workspace changes and build again.
+# Copy the local workspace changes.
 COPY --chown=builder:users workspace /src/workspace/
-RUN ["bazel", "build", "--show_timestamps", "--config=remote", "//..."]
-
 # Add builder's editor configs and other dotfiles.
-# Generate compilation database for the first time.
 COPY --chown=builder:users home /home/builder/
+# Generate compilation database for the first time.
 RUN ["tools/built/dev/setup.sh"]
 
 # Set this to your GitHub username so the git remotes are set up correctly.
 ENV GITHUB_USER=iphydf
 
-# hadolint ignore=DL3002
-USER root
 ENTRYPOINT ["/src/workspace/tools/built/dev/init.sh"]

--- a/tools/built/dev/init.sh
+++ b/tools/built/dev/init.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-service ssh start
+sudo service ssh start
 
 if grep "BEGIN" ~builder/key.pem; then
   sudo -i -u builder gpg --import ~builder/key.pem
@@ -15,7 +15,7 @@ if [ ! -d third_party/android/sdk ]; then
   tools/git-remotes "$GITHUB_USER"
 fi
 
-chown -R builder:users /home/builder/.vscode-server /src/workspace/.vscode
+sudo chown -R builder:users /home/builder/.vscode-server /src/workspace/.vscode
 sudo -i -u builder bazel build //...
 
 nc -l 0.0.0.0 2000

--- a/tools/built/src/Dockerfile
+++ b/tools/built/src/Dockerfile
@@ -1,0 +1,13 @@
+FROM toxchat/toktok-stack:latest-third_party
+
+# Now we can copy the entire tree. This is expected to change very often, as it
+# includes all of the sources of all projects.
+COPY --chown=builder:users workspace /src/workspace/
+
+# Append the Docker image default configs to .bazelrc. This allows child images
+# to have their own .bazelrc.local.
+RUN echo "import %workspace%/tools/bazelrc.docker" >> /src/workspace/.bazelrc
+
+# Finally, we run another aquery. This will download some more dependencies, but
+# the most expensive ones should already have been downloaded above.
+RUN bazel aquery --output=proto //... > /dev/null

--- a/tools/built/src/Dockerfile.dev
+++ b/tools/built/src/Dockerfile.dev
@@ -34,6 +34,9 @@ RUN wget -q https://github.com/bazelbuild/bazel-watcher/releases/download/v0.15.
  && install -o root -g root -m 755 ibazel_linux_amd64 /usr/local/bin/ibazel \
  && rm -f ibazel_linux_amd64
 
+# Install Haskell Stack.
+RUN curl -sSL https://get.haskellstack.org/ | sh
+
 USER builder
 
 # Build YCM before everything else, because this one doesn't change much and

--- a/tools/built/src/Dockerfile.dev-hs
+++ b/tools/built/src/Dockerfile.dev-hs
@@ -1,0 +1,7 @@
+# Dev container base image with Haskell Stack.
+#
+FROM toxchat/toktok-stack:latest-dev
+
+RUN stack build
+
+# vim:ft=dockerfile

--- a/tools/built/src/Dockerfile.third_party
+++ b/tools/built/src/Dockerfile.third_party
@@ -33,14 +33,4 @@ COPY workspace/tools/config /src/workspace/tools/config
 COPY workspace/tools/workspace /src/workspace/tools/workspace
 RUN bazel aquery --config=docker --output=proto --show_timestamps //... > /dev/null
 
-# Now we can copy the entire tree. This is expected to change very often, as it
-# includes all of the sources of all projects.
-COPY --chown=builder:users workspace /src/workspace/
-
-# Append the Docker image default configs to .bazelrc. This allows child images
-# to have their own .bazelrc.local.
-RUN echo "import %workspace%/tools/bazelrc.docker" >> /src/workspace/.bazelrc
-
-# Finally, we run another aquery. This will download some more dependencies, but
-# the most expensive ones should already have been downloaded above.
-RUN bazel aquery --output=proto //... > /dev/null
+# vim:ft=dockerfile

--- a/tools/project/haskell/cirrus.yml.in
+++ b/tools/project/haskell/cirrus.yml.in
@@ -1,7 +1,7 @@
 ---
 bazel-opt_task:
   container:
-    image: toxchat/toktok-stack:0.0.31-release
+    image: toxchat/toktok-stack:latest-release
     cpu: 2
     memory: 6G
   configure_script:

--- a/tools/project/update_versions.sh
+++ b/tools/project/update_versions.sh
@@ -2,14 +2,6 @@
 
 set -eux
 
-VERSION=$(make -s version)
-sed -i \
-  -e "s!image: toxchat/toktok-stack:.*-third_party!image: toxchat/toktok-stack:$VERSION-release!" \
-  -e "s!image: toxchat/toktok-stack:.*-release!image: toxchat/toktok-stack:$VERSION-release!" \
-  -e "s!image: toxchat/toktok-stack:.*-debug!image: toxchat/toktok-stack:$VERSION-debug!" \
-  ./*/.cirrus.yml \
-  tools/project/haskell/cirrus.yml.in
-
 for i in hs-*/.github/workflows/ci.yml; do
   for wf in tools/project/haskell/github/*.yml; do
     cp "$wf" "$(dirname "$i")/$(basename "$wf")"


### PR DESCRIPTION
* `latest-third_party` contains the rarely-changing dependencies. It can
  be used as a basis for other similar third-party-only images.
* `latest` contains the latest snapshot including all (often changing)
  source code of all submodules.

Also, get rid of the image versioning. Rolling release is working well for us now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/330)
<!-- Reviewable:end -->
