### PR TITLE
fix: Install a default .bazelrc.local on init.

### DIFF
--- a/tools/built/src/init.sh
+++ b/tools/built/src/init.sh
@@ -14,6 +14,9 @@ if [ ! -d third_party/javacpp/ffmpeg/jar ]; then
   tools/prepare_third_party.sh
 fi
 
+# Install a default .bazelrc.local that works with the dev container.
+if [ ! -f .bazelrc.local ]; then ln -s .bazelrc.local.example .bazelrc.local; fi
+
 if [ -d ~/.vscode-server ]; then sudo chown -R builder:users ~/.vscode-server; fi
 if [ -d /src/workspace/.vscode ]; then sudo chown -R builder:users /src/workspace/.vscode; fi
 


### PR DESCRIPTION
When the user doesn't have one, builds will fail because the config
doesn't know which compiler is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/338)
<!-- Reviewable:end -->
