### PR TITLE
fix: Use a local checkout for the buildx context in kythe build.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -227,6 +227,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [kythe-tables]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -238,7 +241,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          context: "{{defaultContext}}:dockerfiles/kythe/serving"
+          context: dockerfiles/kythe/serving
           tags: toxchat/kythe-serving:latest
           cache-from: type=registry,ref=toxchat/kythe-serving:latest
           cache-to: type=inline


### PR DESCRIPTION
docker/build-push-action action doesn't clone submodules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/407)
<!-- Reviewable:end -->
