### PR TITLE
chore: Don't warn about unused variables in ncurses.

### DIFF
--- a/third_party/BUILD.ncurses
+++ b/third_party/BUILD.ncurses
@@ -418,6 +418,7 @@ cc_library(
         "-D_XOPEN_SOURCE=600",
         "-DBUILDING_NCURSES",
         "-DNCURSES_STATIC",
+        "-Wno-unused",
     ],
     includes = ["include"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
In release mode, an assert is preprocessed out, resulting in this warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/440)
<!-- Reviewable:end -->
