### PR TITLE
chore: Add toxext stuff to third_party.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,6 +119,9 @@ build --experimental_strict_java_deps=error
 #
 ##############################################################################
 
+# Always enable assert() in tests.
+build --per_file_copt='_test.cc?@-UNDEBUG'
+
 # Debug mode.
 build:debug -c dbg
 
@@ -286,9 +289,10 @@ build:gnulike --per_file_copt='external/com_google_absl[:/]@-UNO_FRAME_POINTER,-
 build:gnulike --per_file_copt='//(c-|go-|hs-|jvm-|py_|qtox|toxic|toxins)@-ftrapv'
 build:gnulike --per_file_copt='//(c-|go-|hs-|jvm-|py_|qtox|toxic|toxins)@-pedantic'
 
-build:gnulike --cxxopt='-std=c++17'
+build:gnulike --cxxopt='-std=c++20'
 build:gnulike --conlyopt='-std=c99'
-build:gnulike --per_file_copt='//c-toxcore[:/].*cc$@-std=c++20'
+build:gnulike --per_file_copt='external/openal[:/]@-std=c++17'
+build:gnulike --per_file_copt='//qtox[:/]@-std=c++17'
 
 # Cython code isn't very clean.
 build:clang --per_file_copt='//py_toxcore_c[:/]@-Wno-conditional-uninitialized'

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -783,3 +783,20 @@ new_github_archive(
 load("@io_kythe//:setup.bzl", "kythe_rule_repositories")
 
 kythe_rule_repositories()
+
+# Tox Extension modules
+# =========================================================
+
+new_github_archive(
+    name = "toxext",
+    repo = "toxext/toxext",
+    sha256 = "55c2aabc7ba87a435bb5c68d7ae0513aa3ada11c18a55a3fca2e42231d351a08",
+    version = "v0.0.3",
+)
+
+new_github_archive(
+    name = "tox_extension_messages",
+    repo = "toxext/tox_extension_messages",
+    sha256 = "f72da1fff2f6048c60fd8993fce2fc64aae58aa689744ae5ee5fc4381209b41e",
+    version = "v0.0.3",
+)

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -4,7 +4,12 @@ filegroup(
     name = "third_party",
     srcs = ["@{pkg}//:{pkg}".format(pkg = pkg[len("BUILD."):]) for pkg in glob(
         ["BUILD.*"],
-        exclude = ["BUILD.bazel*"],
+        exclude = [
+            "BUILD.bazel*",
+            # These depend on //c-toxcore, so can't be pre-built.
+            "BUILD.toxext",
+            "BUILD.tox_extension_messages",
+        ],
     )] + [
         "@com_google_googletest//:gtest",
         "@com_google_googletest//:gtest_main",

--- a/third_party/BUILD.tox_extension_messages
+++ b/third_party/BUILD.tox_extension_messages
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(features = ["layering_check"])
+
+cc_library(
+    name = "tox_extension_messages",
+    srcs = ["tox_extension_messages.c"],
+    hdrs = ["tox_extension_messages.h"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = ["@toxext"],
+)

--- a/third_party/BUILD.toxext
+++ b/third_party/BUILD.toxext
@@ -1,0 +1,32 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(features = ["layering_check"])
+
+genrule(
+    name = "public_headers",
+    srcs = [
+        "src/toxext.h",
+        "src/toxext_util.h",
+    ],
+    outs = [
+        "toxext/toxext.h",
+        "toxext/toxext_util.h",
+    ],
+    cmd = """
+        cp $(location src/toxext.h) $(GENDIR)/external/toxext/toxext/toxext.h
+        cp $(location src/toxext_util.h) $(GENDIR)/external/toxext/toxext/toxext_util.h
+    """,
+)
+
+cc_library(
+    name = "toxext",
+    srcs = [
+        "src/toxext.c",
+        "src/toxext.h",
+        "src/toxext_util.h",
+    ],
+    hdrs = [":public_headers"],
+    includes = ["."],
+    visibility = ["//visibility:public"],
+    deps = ["@toktok//c-toxcore"],
+)


### PR DESCRIPTION
We're not importing this stuff into toktok-stack proper, but qtox
depends on it, so we'll treat it as third party dependency and don't
need to apply the same quality standards we apply to proper TokTok
projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-stack/476)
<!-- Reviewable:end -->
