### PR TITLE
chore: Remove rust support in toktok-stack.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -78,22 +78,6 @@ rules_fuzzing_dependencies()
 
 rules_fuzzing_init()
 
-# Rust
-# =========================================================
-
-github_archive(
-    name = "rules_rust",
-    repo = "bazelbuild/rules_rust",
-    sha256 = "7361e08d1b7c40fd67ee52be13884fa1d4cb8e388f3c7e1f4e9458afec29743b",
-    version = "0.26.0",
-)
-
-load("@rules_rust//rust:repositories.bzl", "rust_register_toolchains", "rust_repositories")
-
-rust_repositories()
-
-rust_register_toolchains()
-
 # Haskell
 # =========================================================
 

--- a/third_party/rust/BUILD.bazel
+++ b/third_party/rust/BUILD.bazel
@@ -1,7 +1,0 @@
-load("@rules_rust//rust:defs.bzl", "rust_binary")
-
-rust_binary(
-    name = "hello_world",
-    srcs = ["main.rs"],
-    edition = "2021",
-)

--- a/third_party/rust/main.rs
+++ b/third_party/rust/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello world!")
-}


### PR DESCRIPTION
We don't use it, and it consumes a lot of disk space.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/640)
<!-- Reviewable:end -->
