### PR TITLE
fix: Make Cirrus CI work again.

### DIFF
--- a/tools/built/src/Dockerfile.third_party
+++ b/tools/built/src/Dockerfile.third_party
@@ -11,6 +11,9 @@ RUN useradd -m -g users -G sudo -u 1000 builder \
  && echo "%sudo ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 USER builder
 
+# Needed for Cirrus CI to work.
+RUN mkdir /tmp/cirrus-ci-build
+
 # First, we copy all the unpacked third_party downloads into the image. These
 # are rarely changing, so we won't need to rebuild this part of the image often.
 # Dependencies installed with apt above should never change, as we should be


### PR DESCRIPTION
They silently stopped creating their working directory, so now we need to create it in the image. Very annoying, because now Cirrus no longer supports arbitrary images, because they need to have that tmp directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/651)
<!-- Reviewable:end -->
