### PR TITLE
perf: Attempt to reduce disk usage for building docker images.

### DIFF
--- a/tools/built/src/Dockerfile
+++ b/tools/built/src/Dockerfile
@@ -10,4 +10,6 @@ RUN echo "import %workspace%/tools/bazelrc.docker" >> /src/workspace/.bazelrc
 
 # Finally, we run another aquery. This will download some more dependencies, but
 # the most expensive ones should already have been downloaded above.
-RUN bazel aquery --output=proto //... > /dev/null
+RUN du -sh "$HOME/.cache/bazel/_bazel_builder" \
+ && bazel aquery --output=proto //... > /dev/null \
+ && tools/workspace/cleanup

--- a/tools/built/src/Dockerfile.third_party
+++ b/tools/built/src/Dockerfile.third_party
@@ -30,6 +30,7 @@ COPY BUILD.bazel WORKSPACE .bazelignore .bazelversion /src/workspace/
 COPY third_party /src/workspace/third_party
 COPY tools/config /src/workspace/tools/config
 COPY tools/workspace /src/workspace/tools/workspace
-RUN bazel aquery --config=docker --output=proto --show_timestamps //... > /dev/null
+RUN bazel aquery --config=docker --output=proto --show_timestamps //... > /dev/null \
+ && tools/workspace/cleanup
 
 # vim:ft=dockerfile

--- a/tools/workspace/cleanup
+++ b/tools/workspace/cleanup
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eux
+
+# Delete some large files we don't need for our builds, just to save some disk
+# space on GitHub Actions, which can easily run out of space when given single
+# large Docker layers.
+
+BAZEL_CACHE="$HOME/.cache/bazel/_bazel_builder"
+
+# Before:
+du -sh "$BAZEL_CACHE"
+
+# Haskell profiling libraries. If we want to do profiling, we can use stack.
+# Saves about 1GB.
+sudo find "$BAZEL_CACHE" -name "libHS*_p.a" -delete
+
+# Haskell docs. Saves about 1.2GB.
+readarray -d '' DOCS < <(find "$BAZEL_CACHE"/*/external/rules_haskell_ghc_linux_amd64 -name doc -print0)
+for i in "${DOCS[@]}"; do
+  rm -rf "$i/"
+  BASE_DOCDIR="$i/html/libraries/base-4.17.2.0"
+  mkdir -p "$BASE_DOCDIR"
+  # We need at least this one file, otherwise rules_haskell fails to initialise.
+  touch "$BASE_DOCDIR/base.haddock"
+done
+
+# After:
+du -sh "$BAZEL_CACHE"


### PR DESCRIPTION
There's about 661MiB of docs in the haskell distribution, which is copied over twice, so it's 1322MiB of docs (out of currently 7.5GiB of bazel cache after the initial aquery).

GitHub Actions runs out of disk space when producing the layers for upload. Afterwards, during CI runs, it's fine, but while uploading/compressing layers, it needs to replicate all the files in the layer, so it takes up a lot of additional disk space all at once.

Another future thing we can do is split the layer, e.g. by doing `query` and then `aquery` to first download some things and then extract them and download more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/661)
<!-- Reviewable:end -->
