### PR TITLE
chore: Add llvm-symbolizer to third party.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,6 +126,13 @@ nixpkgs_package(
 )
 
 nixpkgs_package(
+    name = "libllvm",
+    attribute_path = "llvmPackages_16.libllvm",
+    build_file = "//third_party:BUILD.libllvm",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
     name = "autoconf",
     build_file = "//third_party:BUILD.autoconf",
     repository = "@nixpkgs",

--- a/third_party/BUILD.libllvm
+++ b/third_party/BUILD.libllvm
@@ -1,0 +1,7 @@
+exports_files(["bin/llvm-symbolizer"])
+
+filegroup(
+    name = "libllvm",
+    srcs = ["bin/llvm-symbolizer"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
So it's available in msan errors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/683)
<!-- Reviewable:end -->
