### PR TITLE
feat: Add Kotlin support (disabled because it's broken).

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,9 +15,13 @@ build --process_headers_in_dependencies
 #build --remote_cache_compression  # needs newer bazel version
 build --remote_download_outputs=minimal  # use "all" to make YCM work
 build --strict_filesets=true
-build --strict_proto_deps=strict
-build --strict_public_imports=strict
+build --strict_proto_deps=error
+# TODO(iphydf): Enable once we have a more recent version of protobuf that
+# supports --allowed_public_imports.
+#build --strict_public_imports=strict
 build --strict_system_includes=true
+build --experimental_strict_fileset_output
+build --experimental_strict_java_deps=error
 build --enable_platform_specific_config
 build --watchfs
 build --local_cpu_resources=HOST_CPUS
@@ -37,7 +41,7 @@ build --experimental_remotable_source_manifests
 #build --experimental_remote_build_event_upload=minimal
 build --experimental_remote_cache_async
 build --experimental_remote_merkle_tree_cache
-#build --experimental_remote_require_cached
+#build --experimental_remote_require_cached  # needs newer bazel version
 build --experimental_repository_cache_hardlinks
 
 build --experimental_android_compress_java_resources=true
@@ -138,8 +142,6 @@ build:macos --build_tag_filters=-windows
 build --experimental_guard_against_concurrent_changes
 build --experimental_import_deps_checking=warning
 build --experimental_run_validations
-build --experimental_strict_fileset_output
-build --experimental_strict_java_deps=error
 
 ##############################################################################
 #

--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -28,6 +28,7 @@ def Settings(**kwargs):
     return {
       'flags': list(compilation_info.compiler_flags_) + GLIBC_FLAGS,
       'include_paths_relative_to_dir': compilation_info.compiler_working_dir_,
+      'end_col': 0,
     }
 
-  return {}
+  return {'end_col': 0}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,7 +53,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies")
 
 go_rules_dependencies()
 
-# Haskell
+# Nixpkgs
 # =========================================================
 
 github_archive(
@@ -173,6 +173,65 @@ nixpkgs_package(
     build_file = "//third_party:BUILD.perl",
     repository = "@nixpkgs",
 )
+
+# Java/Kotlin
+# =========================================================
+
+#load("@io_tweag_rules_nixpkgs//nixpkgs:nixpkgs.bzl", "nixpkgs_java_configure")
+#
+#nixpkgs_java_configure(
+#    attribute_path = "jdk11.home",
+#    repository = "@nixpkgs",
+#    toolchain = True,
+#    toolchain_name = "nixpkgs_java",
+#    toolchain_version = "11",
+#)
+#
+#github_archive(
+#    name = "rules_proto",
+#    repo = "bazelbuild/rules_proto",
+#    sha256 = "91e8dc46c147a67f1fd7801f1733966db44cade148c1e9a248d90a7e7238bbe7",
+#    version = "6.0.0-rc0",
+#)
+#
+#github_archive(
+#    name = "rules_pkg",
+#    repo = "bazelbuild/rules_pkg",
+#    sha256 = "80d083438f579a9b1b76bb70e0f37a8d053858fa6683671fb1c8e2da0e61e8eb",
+#    version = "0.9.1",
+#)
+#
+#github_archive(
+#    name = "rules_jvm_external",
+#    repo = "bazelbuild/rules_jvm_external",
+#    sha256 = "6cc8444b20307113a62b676846c29ff018402fd4c7097fcd6d0a0fd5f2e86429",
+#    version = "5.3",
+#)
+#
+#github_archive(
+#    name = "io_bazel_stardoc",
+#    repo = "bazelbuild/stardoc",
+#    sha256 = "af5de1753e68de3c2afaf9b804074b60f808cc3f02d757adeea63eb649dfd886",
+#    version = "0.6.2",
+#)
+#
+#github_archive(
+#    name = "rules_kotlin",
+#    repo = "bazelbuild/rules_kotlin",
+#    sha256 = "eec67a1438949f0bec00d6941223ba8009a5e232ef969e6110ccdcfb6d71349c",
+#    version = "v1.9.0",
+#)
+#
+#load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+#
+#kotlin_repositories()
+#
+#load("@rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+#
+#kt_register_toolchains()
+
+# Haskell
+# =========================================================
 
 load(
     "@rules_haskell//haskell:nixpkgs.bzl",

--- a/third_party/kotlin/BUILD.bazel
+++ b/third_party/kotlin/BUILD.bazel
@@ -1,0 +1,7 @@
+#load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
+#
+#kt_jvm_binary(
+#    name = "mytest",
+#    srcs = glob(["*.kt"]),
+#    main_class = "third_party.kotlin.MainKt",
+#)

--- a/third_party/kotlin/Main.kt
+++ b/third_party/kotlin/Main.kt
@@ -1,0 +1,3 @@
+package third_party.kotlin
+
+fun main() = println("Hello")

--- a/tools/bazelrc.boot
+++ b/tools/bazelrc.boot
@@ -9,6 +9,7 @@ build --experimental_disable_external_package
 build --experimental_repository_cache_hardlinks
 build --incompatible_disable_target_provider_fields
 build --incompatible_disallow_empty_glob
+# TODO(iphydf): This breaks rules_kotlin.
 build --incompatible_no_implicit_file_export
 build --incompatible_top_level_aspects_require_providers
 
@@ -18,7 +19,7 @@ build --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 run --host_platform=@io_tweag_rules_nixpkgs//nixpkgs/platforms:host
 
 # Java toolchain.
-build --java_runtime_version=nixpkgs_java_11
-build --tool_java_runtime_version=nixpkgs_java_11
+build --java_runtime_version=nixpkgs_java
+build --tool_java_runtime_version=nixpkgs_java
 build --java_language_version=11
 build --tool_java_language_version=11


### PR DESCRIPTION
It's quite broken right now. To build `//third_party/kotlin:mytest`, do:
```sh
nix-shell -p jdk11.home --run "bazel run //third_party/kotlin:mytest"
chmod 755 \
  external/remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local \
  external/remote_java_tools_linux/java_tools/ijar/ijar
nix-shell -p patchelf --run "patchelf \
  --set-interpreter /nix/store/yaz7pyf0ah88g2v505l38n0f3wg2vzdj-glibc-2.37-8/lib64/ld-linux-x86-64.so.2 \
  --add-rpath /nix/store/yazs3bdl481s2kyffgsa825ihy1adn8f-gcc-12.2.0-lib/lib \
  external/remote_java_tools_linux/java_tools/src/tools/singlejar/singlejar_local"
nix-shell -p patchelf --run "patchelf \
  --set-interpreter /nix/store/yaz7pyf0ah88g2v505l38n0f3wg2vzdj-glibc-2.37-8/lib64/ld-linux-x86-64.so.2 \
  --add-rpath /nix/store/yazs3bdl481s2kyffgsa825ihy1adn8f-gcc-12.2.0-lib/lib \
  external/remote_java_tools_linux/java_tools/ijar/ijar"
bazel run //third_party/kotlin:mytest
```

Related issue: https://github.com/tweag/rules_nixpkgs/issues/278

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/691)
<!-- Reviewable:end -->
