### PR TITLE
chore: Update to zig rules 0.4.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,8 +19,8 @@ github_archive(
 github_archive(
     name = "hermetic_cc_toolchain",
     repo = "uber/hermetic_cc_toolchain",
-    sha256 = "be4f8151f773d03b2a19a9705ef9bd7fe2bf343b7502abb42445ea2fe3f5a7e3",
-    version = "v2.2.1",
+    sha256 = "680a3e008976d2c21ba2fbb7155ac38afe3b7a4e4c1f634f6ed8e55a65e368e8",
+    version = "v3.1.1",
 )
 
 # hermetic_cc_toolchain
@@ -41,8 +41,8 @@ register_toolchains(
 github_archive(
     name = "rules_zig",
     repo = "aherrmann/rules_zig",
-    sha256 = "0a7da1ea28abd2dcb09f01917c49f1036861a8a17366793455fdd9e723600bf1",
-    version = "766a11afd418c181babbf01b121748ded37938d1",
+    sha256 = "89f0b42a004c3f267d772eb20e4d7f74c9f0b93ce13009584c2aac9f2d0ff0f5",
+    version = "v0.4.0",
 )
 
 load(

--- a/tools/built/dev/setup-local.sh
+++ b/tools/built/dev/setup-local.sh
@@ -8,3 +8,14 @@ sleep 1 # wait for daemon to arrive (race, but *shrug*)
 if grep "BEGIN" ~/key.pem; then
   nix-shell -p gnupg --run "gpg --import ~/key.pem"
 fi
+
+# Clean up old sockets and lock files that might be left over from a previous
+# run, as well as from the above import.
+#
+# If we don't do this, gpg will hang trying to connect to the keybox socket.
+rm -f ~/.gnupg/S.*
+rm -f ~/.gnupg/public-keys.d/pubring.db.lock
+
+# Install all the packages from home.nix now that (hopefully) we have a github
+# token.
+nix-shell -p home-manager --run "home-manager switch"


### PR DESCRIPTION
This one renames `zig_package` to `zig_module` while keeping the former for compat. This allows us to upgrade zig-toxcore-c without knife-cut.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/850)
<!-- Reviewable:end -->
