### PR TITLE
chore: Add prettyprinter haskell deps.

### DIFF
--- a/ghc.nix
+++ b/ghc.nix
@@ -61,6 +61,8 @@ with (import <nixpkgs> { });
       network
       parallel
       pretty
+      prettyprinter
+      prettyprinter-ansi-terminal
       process
       QuickCheck
       quickcheck-instances

--- a/third_party/haskell/BUILD.bazel
+++ b/third_party/haskell/BUILD.bazel
@@ -68,6 +68,8 @@ licenses(["notice"])
     "network",
     "parallel",
     "pretty",
+    "prettyprinter",
+    "prettyprinter-ansi-terminal",
     "process",
     "QuickCheck",
     "quickcheck-instances",


### PR DESCRIPTION
We need to migrate to this as ansi-wl-pprint is deprecated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/853)
<!-- Reviewable:end -->
