### PR TITLE
chore: Add libnotify to bazel build.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -737,6 +737,32 @@ new_github_archive(
 )
 
 nixpkgs_package(
+    name = "libnotify.out",
+    attribute_path = "libnotify",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "libnotify",
+    attribute_path = "libnotify.dev",
+    build_file = "@toktok//third_party:BUILD.libnotify",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "glib.out",
+    attribute_path = "glib.out",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "glib",
+    attribute_path = "glib.dev",
+    build_file = "@toktok//third_party:BUILD.glib",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
     name = "x11.out",
     attribute_path = "xorg.libX11.out",
     repository = "@nixpkgs",

--- a/third_party/BUILD.glib
+++ b/third_party/BUILD.glib
@@ -1,0 +1,10 @@
+# bazel
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "glib",
+    srcs = ["@glib.out//:lib"],
+    hdrs = glob(["include/glib-2.0/**/*.h"]),
+    strip_include_prefix = "include/glib-2.0",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/BUILD.libnotify
+++ b/third_party/BUILD.libnotify
@@ -1,0 +1,11 @@
+# bazel
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "libnotify",
+    srcs = ["@libnotify.out//:lib"],
+    hdrs = glob(["include/libnotify/*.h"]),
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = ["@glib"],
+)


### PR DESCRIPTION
Needed for qtox desktop notifications on linux.

Ideally we'd build this in the bazel build, but nixpkgs is second best.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/881)
<!-- Reviewable:end -->
