### PR TITLE
fix: Use Qt RCC format version 1 to avoid storing mtime.

### DIFF
--- a/third_party/qt/build_defs.bzl
+++ b/third_party/qt/build_defs.bzl
@@ -119,6 +119,11 @@ def _qt_rcc_impl(ctx):
         arguments = [src.path for src in srcs] + [
             "--name",
             ctx.attr.name,
+            # Drop the file modification time of source files from generated files
+            # to help with reproducible builds. We do not use QFileInfo.lastModified
+            # so this has no unwanted side effects.
+            "-format-version",
+            "1",
             "--compress",
             "9",
             "--threshold",


### PR DESCRIPTION
We need this for reproducible builds and better caching.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/892)
<!-- Reviewable:end -->
