### PR TITLE
fix: bazel 8 no longer reads WORKSPACE by default

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,12 +35,14 @@ services:
     <<: *shared_params
     command: bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       //...
 
   arm64:
     <<: *shared_params
     command: bazel build
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=linux-arm64-musl
       //...
 
@@ -48,6 +50,7 @@ services:
     <<: *shared_params
     command: tools/retry 3 bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=asan
       --build_tag_filters=-haskell,-fuzz-test
       --test_tag_filters=-haskell,-fuzz-test
@@ -57,6 +60,7 @@ services:
     <<: *shared_params
     command: tools/retry 3 bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=msan
       --build_tag_filters=-haskell,-fuzz-test
       --test_tag_filters=-haskell,-fuzz-test
@@ -69,6 +73,7 @@ services:
     <<: *shared_params
     command: bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=tsan
       --build_tag_filters=-haskell,-fuzz-test
       --test_tag_filters=-haskell,-fuzz-test
@@ -78,6 +83,7 @@ services:
     <<: *shared_params
     command: bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=debug
       --build_tag_filters=-haskell,-macos
       --test_tag_filters=-haskell,-macos
@@ -87,6 +93,7 @@ services:
     <<: *shared_params
     command: bazel test
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=release
       //...
 
@@ -94,5 +101,6 @@ services:
     <<: *shared_params
     command: bazel build
       --remote_cache=grpc://bazel-cache:9092
+      --enable_workspace=true
       --config=windows-x86_64
       //...

--- a/tools/built/src/Dockerfile.third_party
+++ b/tools/built/src/Dockerfile.third_party
@@ -17,6 +17,6 @@ COPY --chown=builder:users tools/config /src/workspace/tools/config
 COPY --chown=builder:users tools/workspace /src/workspace/tools/workspace
 WORKDIR /src/workspace
 RUN echo 'build --config=nix' >>.bazelrc \
- && sudo nix-daemon --daemon & bazel aquery --output=proto --show_timestamps //... > /dev/null
+ && sudo nix-daemon --daemon & bazel aquery --enable_workspace=true --output=proto --show_timestamps //... > /dev/null
 
 # vim:ft=dockerfile


### PR DESCRIPTION
need to migrate https://bazel.build/external/migration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/toktok-stack/1034)
<!-- Reviewable:end -->
